### PR TITLE
fix(factory): Default createCollectionState param to empty object

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -59,7 +59,7 @@ const createMetaData = useCursor => (useCursor ? createCursorMeta() : createDefa
  *  selectedEntityId: null,
  * }
  */
-export const createCollectionState = (state, options = {}) => ({
+export const createCollectionState = (state = {}, options = {}) => ({
   entities: {},
   meta: createMetaData(options.useCursor),
   selectedEntityId: null,


### PR DESCRIPTION
State param defaults to empty object.

ie.
```
export const createCollectionState = (state = {}, options = {}) => ({
```