### PR TITLE
build(travis): disable caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ env:
 language: node_js
 dist: trusty
 
-cache:
-  directories:
-    - ~/.npm
-    - node_modules
-
 notifications:
   email: false
 


### PR DESCRIPTION
This should fix the random Travis build errors related to `pack.js`

ie.
```
npm ERR! Cannot find module '../pack.js'
```