### PR TITLE
fix(createReducer): should prioritise custom actions before default actions

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -149,8 +149,8 @@ export const createReducer = (
 ) => (state = initialState, action) => {
   const { type, payload } = action;
   const reducer = selectReducer(actionTypes, type);
-  return (reducer && reducer(state, payload)) || (
+  return (
     Object.prototype.hasOwnProperty.call(handlers, type)
-      ? handlers[type](state, action) : state
-  );
+    && handlers[type](state, action)
+  ) || (reducer ? reducer(state, payload) : state);
 };

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -274,5 +274,21 @@ describe('reducer.js', () => {
         payload: 'test',
       })).toMatchObject(initialState);
     });
+
+    it('should prioritise custom actions before default actions', () => {
+      const { types } = createActions('collection', ['select']);
+      const reducerFunction = reducer.createReducer(initialState, {
+        type: types.SELECT,
+        payload: 'test',
+      }, {
+        [types.SELECT]: state => ({
+          ...state, selectedEntityId: 'override',
+        }),
+      });
+      expect(reducerFunction(initialState, { type: types.SELECT, payload: 'something' })).toMatchObject({
+        ...initialState,
+        selectedEntityId: 'override',
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes the issue of not being able to override default action creators with custom handlers.